### PR TITLE
change `Method.POST` to `post`

### DIFF
--- a/resources/js/Layouts/GuestLayout.tsx
+++ b/resources/js/Layouts/GuestLayout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import ApplicationLogo from '@/Components/ApplicationLogo';
 import { Link } from '@inertiajs/react';
-import route from "ziggy-js";
+import route from 'ziggy-js';
 
 interface GuestLayoutProps {
     children: ReactNode;

--- a/resources/js/Layouts/Navbar.tsx
+++ b/resources/js/Layouts/Navbar.tsx
@@ -3,7 +3,6 @@ import NavLink from '@/Components/NavLink';
 import ApplicationLogo from '@/Components/ApplicationLogo';
 import Dropdown from '@/Components/Dropdown';
 import useTypedPage from '@/Hooks/useTypedPage';
-import { Method } from '@inertiajs/core';
 import route from 'ziggy-js';
 
 export default function Navbar() {
@@ -52,7 +51,7 @@ export default function Navbar() {
                                     Settings
                                 </Dropdown.Link>
                                 <Dropdown.Divider />
-                                <Dropdown.Link href={route('logout')} method={Method.POST} as='button'>
+                                <Dropdown.Link href={route('logout')} method='post' as='button'>
                                     Log out
                                 </Dropdown.Link>
                             </Dropdown>

--- a/resources/js/Pages/Auth/Login.tsx
+++ b/resources/js/Pages/Auth/Login.tsx
@@ -6,7 +6,7 @@ import InputLabel from '@/Components/InputLabel';
 import PrimaryButton from '@/Components/PrimaryButton';
 import TextInput from '@/Components/TextInput';
 import { Head, Link, useForm } from '@inertiajs/react';
-import route from "ziggy-js";
+import route from 'ziggy-js';
 
 interface LoginProps {
     status: string;

--- a/resources/js/Pages/Auth/VerifyEmail.tsx
+++ b/resources/js/Pages/Auth/VerifyEmail.tsx
@@ -1,7 +1,6 @@
 import GuestLayout from '@/Layouts/GuestLayout';
 import PrimaryButton from '@/Components/PrimaryButton';
 import { Head, Link, useForm } from '@inertiajs/react';
-import { Method } from '@inertiajs/core';
 
 export default function VerifyEmail({ status }: { status?: any }) {
     const { post, processing } = useForm();
@@ -33,7 +32,7 @@ export default function VerifyEmail({ status }: { status?: any }) {
                     </PrimaryButton>
                     <Link
                         href={'/logout'}
-                        method={Method.POST}
+                        method='post'
                         as='button'
                         className='text-sm text-gray-600 underline hover:text-gray-900'>
                         Log Out

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
@@ -7,8 +7,7 @@ import { Link, useForm } from '@inertiajs/react';
 import { Transition } from '@headlessui/react';
 import useTypedPage from '@/Hooks/useTypedPage';
 import { ProfileEditProps } from '@/types';
-import { Method } from '@inertiajs/core';
-import route from "ziggy-js";
+import route from 'ziggy-js';
 
 interface UpdateProfileInformationProps extends ProfileEditProps {
     className?: string;
@@ -95,7 +94,7 @@ export default function UpdateProfileInformation({
                                 Your email address is unverified.
                                 <Link
                                     href={route('verification.send')}
-                                    method={Method.POST}
+                                    method='post'
                                     as='button'
                                     className='text-gray-600 underline hover:text-gray-900'>
                                     Click here to re-send the verification email.

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -1,9 +1,9 @@
 import './bootstrap';
 import '../css/app.css';
 
-import {createRoot} from 'react-dom/client';
-import {createInertiaApp} from '@inertiajs/react';
-import {resolvePageComponent} from 'laravel-vite-plugin/inertia-helpers';
+import { createRoot } from 'react-dom/client';
+import { createInertiaApp } from '@inertiajs/react';
+import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 
 const appName = window.document.getElementsByTagName('title')[0]?.innerText || 'Indo Carving';
 
@@ -11,10 +11,9 @@ createInertiaApp({
     title: (title) => `${title} - ${appName}`,
     // @ts-ignore
     resolve: (name) => resolvePageComponent(`./Pages/${name}.tsx`, import.meta.glob('./Pages/**/*.tsx')),
-    setup({el, App, props}) {
+    setup({ el, App, props }) {
         const root = createRoot(el);
-        return root.render(<App {...props} />
-        );
+        return root.render(<App {...props} />);
     },
-    progress: {color: '#4B5563'},
+    progress: { color: '#4B5563' },
 });


### PR DESCRIPTION
Since inertia v1.0, to implement a method inside a `<Link/>` component, we should use `Method.POST`. And now in `v1.0.1` it asks for replace to be a string method like `post`, `get`, etc.